### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,57 +4,57 @@
 # Class
 #######################################
 
-RoDi            KEYWORD1
-RoDIBuzzer      KEYWORD1
-RoDILeds        KEYWORD1
-RoDILineSensor  KEYWORD1
-RoDIMotors      KEYWORD1
-RoDISonars      KEYWORD1
+RoDi	KEYWORD1
+RoDIBuzzer	KEYWORD1
+RoDILeds	KEYWORD1
+RoDILineSensor	KEYWORD1
+RoDIMotors	KEYWORD1
+RoDISonars	KEYWORD1
 
 #######################################
 # Methods and Functions
 #######################################
 
-read            KEYWORD2
-read_cm         KEYWORD2
-begin           KEYWORD2
-clear           KEYWORD2
-toggle          KEYWORD2
-write           KEYWORD2
-rainbow         KEYWORD2
-drive           KEYWORD2
-pivot           KEYWORD2
-rightMotor      KEYWORD2
-leftMotor       KEYWORD2
-stop            KEYWORD2
-read            KEYWORD2
-check           KEYWORD2
-setBGLevel      KEYWORD2
-setDetectLevel  KEYWORD2
-calStatus       KEYWORD2
-play_tone       KEYWORD2
-play_melody     KEYWORD2
+read	KEYWORD2
+read_cm	KEYWORD2
+begin	KEYWORD2
+clear	KEYWORD2
+toggle	KEYWORD2
+write	KEYWORD2
+rainbow	KEYWORD2
+drive	KEYWORD2
+pivot	KEYWORD2
+rightMotor	KEYWORD2
+leftMotor	KEYWORD2
+stop	KEYWORD2
+read	KEYWORD2
+check	KEYWORD2
+setBGLevel	KEYWORD2
+setDetectLevel	KEYWORD2
+calStatus	KEYWORD2
+play_tone	KEYWORD2
+play_melody	KEYWORD2
 
 #######################################
 # Constants
 #######################################
 
-LEFT_SERVO          LITERAL1
-RIGHT_SERVO         LITERAL1
-LEFT_HALL           LITERAL1
-RIGHT_HALL          LITERAL1
-LEFT_US_TRIGGER     LITERAL1
-LEFT_US_ECHO        LITERAL1
-CENTER_US_TRIGGER   LITERAL1
-CENTER_US_ECHO      LITERAL1
-RIGHT_US_TRIGGER    LITERAL1
-RIGHT_US_ECHO       LITERAL1
-BUZZER              LITERAL1
-USER_LED            LITERAL1
-WS2812b_LED         LITERAL1
-IMU_SDA             LITERAL1
-IMU_SCL             LITERAL1
-BATTERY_MON         LITERAL1
-LDR                 LITERAL1
-LEFT_LINE           LITERAL1
-RIGHT_LINE          LITERAL1
+LEFT_SERVO	LITERAL1
+RIGHT_SERVO	LITERAL1
+LEFT_HALL	LITERAL1
+RIGHT_HALL	LITERAL1
+LEFT_US_TRIGGER	LITERAL1
+LEFT_US_ECHO	LITERAL1
+CENTER_US_TRIGGER	LITERAL1
+CENTER_US_ECHO	LITERAL1
+RIGHT_US_TRIGGER	LITERAL1
+RIGHT_US_ECHO	LITERAL1
+BUZZER	LITERAL1
+USER_LED	LITERAL1
+WS2812b_LED	LITERAL1
+IMU_SDA	LITERAL1
+IMU_SCL	LITERAL1
+BATTERY_MON	LITERAL1
+LDR	LITERAL1
+LEFT_LINE	LITERAL1
+RIGHT_LINE	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords